### PR TITLE
Adds table stock_quote, and removes current_price from stock

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,3 +1,5 @@
+require 'iex-ruby-client'
+
 class PagesController < ApplicationController
   def landing
     @stocks = Stock.all

--- a/app/controllers/trades_controller.rb
+++ b/app/controllers/trades_controller.rb
@@ -12,7 +12,7 @@ class TradesController < ApplicationController
     @trade = Trade.new(trade_params)
     @trade.user_id = current_user.id
     @trade.stock_code = params[:stock_code]
-    @trade.price = @stock.current_price
+    @trade.price = @stock.stock_quote.latest_price
     @trade.total_price = CalculateTotalTradePrice.call(@stock, params[:trade][:quantity].to_i)
 
     if @trade.save

--- a/app/models/stock.rb
+++ b/app/models/stock.rb
@@ -1,9 +1,9 @@
 class Stock < ApplicationRecord
   self.primary_key = 'code'
-  has_many :trades, dependent: :destroy
-  has_many :stocks, through: :trades
+  has_many :trades, dependent: :destroy, foreign_key: 'stock_code', inverse_of: :stock
+  has_many :users, through: :trades
+  has_one :stock_quote, dependent: :destroy, foreign_key: 'stock_code', inverse_of: :stock
 
   validates :code, presence: true
   validates :name, presence: true
-  validates :current_price, presence: true, numericality: { greater_than: 0 }, on: :update
 end

--- a/app/models/stock_quote.rb
+++ b/app/models/stock_quote.rb
@@ -1,0 +1,5 @@
+class StockQuote < ApplicationRecord
+  belongs_to :stock, foreign_key: 'stock_code', inverse_of: :stock_quote
+
+  validates :latest_price, presence: true, numericality: { greater_than: 0 }
+end

--- a/app/services/calculate_total_trade_price.rb
+++ b/app/services/calculate_total_trade_price.rb
@@ -9,6 +9,6 @@ class CalculateTotalTradePrice
   end
 
   def execute
-    @total_price = @stock.current_price * @quantity
+    @total_price = @stock.stock_quote.latest_price * @quantity
   end
 end

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -22,7 +22,7 @@
     <% @stocks.each do |stock| %>
       <div>
         <%= stock.code %>
-        <%= stock.current_price %>
+        <%= stock.stock_quote.latest_price %>
         <%= link_to 'Buy/Sell', new_stock_trade_path(stock) %>
       </div>
     <% end %>

--- a/app/views/trades/new.html.erb
+++ b/app/views/trades/new.html.erb
@@ -19,7 +19,7 @@
   <%= f.label :transaction_type, "Buy/Sell" %>
   <%= f.select :transaction_type, [["Buy", "buy"], ["Sell", "sell"]] %>
   <%= f.label :price %>
-  <%= f.number_field :price, value: @stock.current_price, disabled: true %>
+  <%= f.number_field :price, value: @stock.stock_quote.latest_price, disabled: true %>
   <%= f.label :quantity %>
   <%= f.number_field :quantity %>
   <%= f.submit "Submit", disable_with: 'Processing...' %>

--- a/db/migrate/20210910112644_create_stocks.rb
+++ b/db/migrate/20210910112644_create_stocks.rb
@@ -3,7 +3,7 @@ class CreateStocks < ActiveRecord::Migration[6.0]
     create_table :stocks, id: false, primary_key: :code do |t|
       t.string :code
       t.string :name
-      t.float :current_price
+      # t.float :current_price
 
       t.timestamps
     end

--- a/db/migrate/20210920080025_create_stock_quotes.rb
+++ b/db/migrate/20210920080025_create_stock_quotes.rb
@@ -1,0 +1,13 @@
+class CreateStockQuotes < ActiveRecord::Migration[6.0]
+  def change
+    create_table :stock_quotes do |t|
+      t.string :stock_code, foreign_key: true
+      t.float :change
+      t.string :change_percent_s
+      t.string :latest_time
+      t.float :latest_price
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_18_141908) do
+ActiveRecord::Schema.define(version: 2021_09_20_080025) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,10 +29,19 @@ ActiveRecord::Schema.define(version: 2021_09_18_141908) do
     t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
   end
 
+  create_table "stock_quotes", force: :cascade do |t|
+    t.string "stock_code"
+    t.float "change"
+    t.string "change_percent_s"
+    t.string "latest_time"
+    t.float "latest_price"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "stocks", id: false, force: :cascade do |t|
     t.string "code"
     t.string "name"
-    t.float "current_price"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,5 @@
 require 'iex-ruby-client'
+client = IEX::Api::Client.new
 
 def map_stocks(stocks)
   stocks = stocks.map do |stock|
@@ -6,16 +7,20 @@ def map_stocks(stocks)
   end
 end
 
-client = IEX::Api::Client.new
-
-Stock.destroy_all ##For testing only
-@stocks = map_stocks(client.ref_data_symbols_for_exchange('NAS').first(10)) ##10 For testing only
+Stock.destroy_all
+@stocks = map_stocks(client.ref_data_symbols_for_exchange('NAS').first(10))
 Stock.create!(@stocks)
 
 Stock.all.map do |stock|
-  stock.update!(current_price: client.price('MSFT')) #MSFT for development only
-  # stock.update!(current_price: client.price(stock.code))
+  quote = client.quote(stock.code)
+
+  if quote.latest_price == nil || quote.latest_price == 0
+    stock.delete
+    next
+  end
+
+  StockQuote.create!(stock_code: stock.code, change: quote.change, change_percent_s: quote.change_percent_s, latest_time: quote.latest_time, latest_price: quote.latest_price)
 end
 
 puts "Created #{Stock.count} stocks"
-puts "Updated current prices"
+puts "Created stock quotes"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
   factory :stock do
     code { 'AAPL' }
     name { 'Apple' }
-    current_price { 1_000 }
+    # current_price { 1_000 }
   end
 
   factory :trade do
@@ -28,5 +28,13 @@ FactoryBot.define do
     stock_code { 'AAPL' }
     quantity { 1_000 }
     association :user
+  end
+
+  factory :stock_quote do
+    change { 10 }
+    change_percent_s { '10%' }
+    latest_time { 'September 17, 2021' }
+    latest_price { 1_000 }
+    association :stock
   end
 end

--- a/spec/models/stock_quote_spec.rb
+++ b/spec/models/stock_quote_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe StockQuote, type: :model do
+  context 'when validating associations' do
+    it { is_expected.to belong_to(:stock).with_foreign_key('stock_code') }
+  end
+
+  context 'when validating presence' do
+    it { is_expected.to validate_presence_of(:latest_price) }
+  end
+
+  context 'when validating values for numerals' do
+    it { is_expected.to validate_numericality_of(:latest_price).is_greater_than(0) }
+  end
+end

--- a/spec/models/stock_spec.rb
+++ b/spec/models/stock_spec.rb
@@ -4,10 +4,5 @@ RSpec.describe Stock, type: :model do
   context 'when validating presence' do
     it { is_expected.to validate_presence_of(:code) }
     it { is_expected.to validate_presence_of(:name) }
-    it { is_expected.to validate_presence_of(:current_price).on(:update) }
-  end
-
-  context 'when validating values for numerals' do
-    it { is_expected.to validate_numericality_of(:current_price).is_greater_than(0).on(:update) }
   end
 end


### PR DESCRIPTION
New table 'stock_quote' has been added to represent the corresponding latest quotes for each stock. Originally, stock model has an attribute 'current_price', which holds the latest price of each stock. As the API endpoint to get a list of stock symbols returns values excluding the price attribute, it is practical to exclude the price from the stock model to isolate errors that may arise when fetching prices.

For instance, a previous object will be created:  Stock => code: 'AAPL', name: 'Apple', current_price: 1000.
When fetching the stock symbol form the API, the 'code' and 'name' might return correctly. Then another call is required to fetch the 'price'. When the price fails to return correctly, say it returns nil, the stock object Stock => code: 'AAPL', name: 'Apple', current_price: nil will not be created. Whereas if the price is separated from the model, the stock object will still be saved.

Other attributes were also added on the stock_quote. 