### PR TITLE
Removes private keys for IEX API configuration

### DIFF
--- a/config/initializers/iex_client.rb
+++ b/config/initializers/iex_client.rb
@@ -1,4 +1,5 @@
 IEX::Api.configure do |config|
-  config.publishable_token = 'Tpk_603243bdac5b4a0887544d42868da69a' # defaults to ENV['IEX_API_PUBLISHABLE_TOKEN']
+  config.publishable_token = ENV['IEX_API_PUBLISHABLE_TOKEN']
+  config.secret_token = ENV['IEX_API_SECRET_TOKEN']
   config.endpoint = 'https://sandbox.iexapis.com/v1'
 end


### PR DESCRIPTION
### Story
Previously, IEX configuration keys were shown on the repo, which can be viewed publicly. This PR removes the values and kept on environment variables, and adds the missing configuration.