### PR TITLE
Fixes wallet validation for trade model

### DIFF
--- a/app/models/trade.rb
+++ b/app/models/trade.rb
@@ -16,7 +16,7 @@ class Trade < ApplicationRecord
     user_wallet = Wallet.find_by(user_id: user_id)
     user_wallet_balance = user_wallet.try { running_balance }
 
-    return unless user_wallet_balance
+    return errors.add(:total_price, 'is exceeding your wallet balance, or you might not have an existing wallet.') if transaction_type == 'buy' && user_wallet_balance.nil?
 
     errors.add(:total_price, 'is exceeding your wallet balance') if transaction_type == 'buy' && user_wallet_balance < total_price
   end

--- a/spec/requests/trades_spec.rb
+++ b/spec/requests/trades_spec.rb
@@ -58,6 +58,10 @@ RSpec.describe 'Trades', type: :request do
       expect(user.user_stocks.find_by(stock_code: stock.code).quantity).to eq(900)
     end
 
+    it 'does not create trade if user does not have a wallet' do
+      expect { post create_trade_path(stock.code), params: { trade: { user_id: user.id, stock_code: stock.code, price: stock.current_price, quantity: 10_000_000, transaction_type: 'buy' } } }.to change { user.trades.count }.by(0)
+    end
+
     it 'does not create trade if user has insufficient balance on "buy" transaction' do
       wallet
       expect { post create_trade_path(stock.code), params: { trade: { user_id: user.id, stock_code: stock.code, price: stock.current_price, quantity: 10_000_000, transaction_type: 'buy' } } }.to change { user.trades.count }.by(0)


### PR DESCRIPTION
### Story
When user is created, he still does not have a virtual wallet which he can use for buying stocks. Per the User Story #5, the user should be approve before he can buy a stock. For this app, we are allowing the user to navigate the buy and sell page. The user  is allowed to try navigating the buy/sell page, even if his registration is still not approved. Once the registration is approved, that's the only time that his wallet is created.

Previous version of the app has a model validation to check if the user has sufficient balance in his wallet. If the validation fails, the transaction will not proceed. 

Upon trying to create a buy transaction, the transaction proceeds even if the user's wallet does not exist yet. I reviewed the model validation and found that I returned early on the validation if the wallet is not present. To correct this, I added a validation error if the wallet does not exist.


### Sreenshots

![image](https://user-images.githubusercontent.com/81558435/134280084-d3e58a6d-e737-4496-936f-8cdf961a5d1e.png)

![image](https://user-images.githubusercontent.com/81558435/134280320-7ef0a4e7-f47b-4029-af1c-f8baa32443ba.png)

