### PR TITLE
Updates production environment configuration to precompile assets

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -26,7 +26,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'
@@ -109,4 +109,6 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+  config.public_file_server.enabled = true
+  config.serve_static_assets = true
 end


### PR DESCRIPTION
### Story
After deploying to heroku, bootstrap and other css styles are not showing on the page. I have been advised to precompile the files so assets will load properly on heroku. I have followed the reference below for the setup.

### Reference
https://github.com/avionschool/batch9-activities/discussions/113