### PR TITLE
Updates bootstrap version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.3.0",
-    "bootstrap": "^5.1.1",
+    "bootstrap": "5.0.0",
     "turbolinks": "^5.2.0"
   },
   "version": "0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1494,10 +1494,10 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
-bootstrap@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.1.1.tgz#9d6eed81e08feaccedf3adaca51fe4b73a2871df"
-  integrity sha512-/jUa4sSuDZWlDLQ1gwQQR8uoYSvLJzDd8m5o6bPKh3asLAMYVZKdRCjb1joUd5WXf0WwCNzd2EjwQQhupou0dA==
+bootstrap@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.0.0.tgz#97635ac0e0d6cb466700ebf0fd266bfabf352ed2"
+  integrity sha512-tmhPET9B9qCl8dCofvHeiIhi49iBt0EehmIsziZib65k1erBW1rHhj2s/2JsuQh5Pq+xz2E9bEbzp9B7xHG+VA==
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
### Story
With reference to pull request https://github.com/brandomoreno06/trading-app/pull/21, after deploying to heroku, bootstrap styles are still not showing on the page. 

After gathering insights from discussion https://github.com/avionschool/batch9-activities/discussions/166, it seems that the same problem has been encountered before. To test it, I have installed the bootstrap version 5.0.0 which also modifies the associated files (package.json and yarn.lock) on this repo. 