### PR TITLE
Adds wallet and sets registration status as approved when the admin creates a trader account

### DIFF
--- a/app/controllers/admin_portals_controller.rb
+++ b/app/controllers/admin_portals_controller.rb
@@ -32,8 +32,13 @@ class AdminPortalsController < ApplicationController
 
   def create_user
     @user = User.new(params.require(:user).permit(:username, :first_name, :last_name, :email, :password, :password_confirmation))
-    @user.save
-    redirect_to admins_home_path if @user.save
+    if @user.save && @user.update(status: 'approved')
+      CreateUserWallet.call(@user)
+      redirect_to admins_home_path
+    else
+      flash[:error] = @user.errors.full_messages.first
+      redirect_to admins_add_user_path
+    end
   end
 
   def show_pending_users


### PR DESCRIPTION
### Story
Previously, wallet is created only after the admin has approved the user's registration. As the admin is able to create users from his dashboard, it is necessary to set the registration status as 'approved' and create the wallet directly.