### PR TITLE
Adds missing bootstrap dependency, updates buy/sell buttons, and adds most active stocks on home page

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -12,14 +12,18 @@
   color: red;
 }
 
-.selectTransaction.buy {
-  border-color: green;
-  color: green !important;
+.transaction_type_buy_button {
+  border-color: green !important;
+  background-color: green !important;
+  color: white !important;
+  width: 45% !important;
 }
 
-.selectTransaction.sell {
+.transaction_type_sell_button {
   border-color: red;
-  color: red !important;
+  background-color: rgb(156, 4, 4) !important;
+  color: white !important;
+  width: 45% !important;
 }
 
 .submit__transaction {

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -12,6 +12,6 @@ class PagesController < ApplicationController
   end
 
   def transactions
-    @transactions = current_user.trades.order(:created_at).reverse
+    @transactions = current_user.trades.order('created_at DESC').page params[:page]
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -5,6 +5,7 @@ class PagesController < ApplicationController
 
   def home
     @stocks = Stock.all
+    @most_active_stocks ||= IEX::Api::Client.new.stock_market_list(:mostactive)
   end
 
   def portfolio

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -5,7 +5,7 @@ class PagesController < ApplicationController
 
   def home
     @stocks = Stock.all
-    @most_active_stocks ||= IEX::Api::Client.new.stock_market_list(:mostactive)
+    @home ||= IEX::Api::Client.new.stock_market_list(:mostactive)
   end
 
   def portfolio

--- a/app/controllers/stocks_controller.rb
+++ b/app/controllers/stocks_controller.rb
@@ -1,6 +1,7 @@
 class StocksController < ApplicationController
   def index
     @stocks = Stock.order(:code).page params[:page]
+    render :index
     UpdateStocksPrice.execute(@stocks)
   end
 

--- a/app/javascript/packs/new_transaction.js
+++ b/app/javascript/packs/new_transaction.js
@@ -1,28 +1,13 @@
-const selectTransaction = document.querySelector("#trade_transaction_type");
+const selectTransactionBuy = document.querySelector(".transaction_type_buy_button");
+const selectTransactionSell = document.querySelector(".transaction_type_sell_button");
 const submitTransaction = document.querySelector(".submit__transaction");
-const quantityInput = document.querySelector("#trade_quatity");
 
-function modifyTransactionType () {
-  if (this.value == 'buy') {
-    this.classList.add('buy')
-    this.classList.remove('sell')
-    submitTransaction.classList.add('buy')
-    submitTransaction.classList.remove('sell')
-  } else {
-    this.classList.add('sell')
-    this.classList.remove('buy')
-    submitTransaction.classList.add('sell')
-    submitTransaction.classList.remove('buy')
-  }
-}
+selectTransactionBuy.addEventListener('click', () => {
+  submitTransaction.classList.add('buy')
+  submitTransaction.classList.remove('sell')
+})
 
-selectTransaction.addEventListener('change', modifyTransactionType)
-selectTransaction.addEventListener('load', modifyTransactionType)
-
-selectTransaction.addEventListener('click', function () {
-  if (this.value == 'buy') {
-    this.style.borderColor = 'green'
-  } else {
-    this.style.borderColor = 'red'
-  }
-});
+selectTransactionSell.addEventListener('click', () => {
+  submitTransaction.classList.add('sell')
+  submitTransaction.classList.remove('buy')
+})

--- a/app/models/trade.rb
+++ b/app/models/trade.rb
@@ -1,4 +1,5 @@
 class Trade < ApplicationRecord
+  paginates_per 15
   belongs_to :user
   belongs_to :stock, foreign_key: 'stock_code', inverse_of: :trades
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,8 +5,9 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
   </head>
 
   <body>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,11 +1,10 @@
 <div class="container">
-  <h1>User Dashboard</h1>
-  
   <% if current_user %>
     <div>
       <h1>Wallet</h1>
-      <%= current_user.wallet.try{running_balance} %>
+      <h5><%= number_to_currency(current_user.wallet.try{running_balance}) %></h5>
     </div>
+  <% end %>
   
     <div>
       <h1>Stocks</h1>
@@ -17,5 +16,5 @@
         </div>
       <% end %>
     </div>
-  <% end %>
+  
 </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,20 +1,39 @@
-<div class="container">
+<div class="container mt-5">
   <% if current_user %>
-    <div>
-      <h1>Wallet</h1>
-      <h5><%= number_to_currency(current_user.wallet.try{running_balance}) %></h5>
+    <div class= "card text-center mb-5">
+      <div class="card-body">
+        <% if current_user.approved? %>
+          <h2 class="card-title">Wallet</h2>
+          <h2><%= number_to_currency(current_user.wallet.try{running_balance}) %></h2>
+        <% else %>
+          <h3>Your account is still pending for approval.</h3>
+          <h5>You can not buy or sell stocks yet, but you may navigate the pages.</h5>
+        <% end %>
+      </div>
     </div>
   <% end %>
-  
-    <div>
-      <h1>Stocks</h1>
-      <% @stocks.each do |stock| %>
-        <div>
-          <%= stock.code %>
-          <%= stock.current_price %>
-          <%= link_to 'Buy/Sell', new_stock_trade_path(stock) %>
-        </div>
+
+  <div class="container">
+    <h1>Most Active Stocks</h1>
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Symbol</th>
+          <th>Company Name</th>
+          <th class= "text-center">Average Volume</th>
+          <th class= "text-center">Change</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @most_active_stocks.each do |stock| %>
+        <tr>
+          <td><%= stock.symbol %></td>
+          <td><%= stock.company_name %></td>
+          <td class= "text-center"><%= number_to_currency(stock.avg_total_volume) %></td>
+          <td class= "text-center <%= stock.change_percent > 0 ? 'buy' : 'sell' %>"><%= number_to_percentage(stock.change_percent * 100, precision: 2) %></td>
+        </tr>
       <% end %>
-    </div>
-  
+      </tbody>
+    </table>
+  </div>
 </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -25,7 +25,7 @@
         </tr>
       </thead>
       <tbody>
-        <% @most_active_stocks.each do |stock| %>
+        <% @home.each do |stock| %>
         <tr>
           <td><%= stock.symbol %></td>
           <td><%= stock.company_name %></td>

--- a/app/views/pages/transactions.html.erb
+++ b/app/views/pages/transactions.html.erb
@@ -1,3 +1,4 @@
 <div class= 'container mt-5'>
   <%= render 'shared/transactions', transactions: @transactions %>
+  <%= paginate @transactions %>
 </div>

--- a/app/views/trades/new.html.erb
+++ b/app/views/trades/new.html.erb
@@ -12,9 +12,11 @@
     
     <div class="col-12 col-md-6 mb-5">
       <%= form_with scope: :trade, url: create_trade_path(@stock.code), local: true do |f| %>
-        <div class="field mb-3">
-          <%= f.label :transaction_type, "Buy/Sell", class: 'form-label' %>
-          <%= f.select :transaction_type, [["Buy", "buy", class: 'buy'], ["Sell", "sell", class: 'sell']], {}, class: 'selectTransaction buy form-control' %>
+        <div class="field mb-3 d-flex justify-content-between">
+          <%= f.radio_button :transaction_type, 'buy', checked: true, class: "btn-check" %>
+          <%= f.label :transaction_type_buy, "Buy", class: 'btn btn-secondary transaction_type_buy_button' %>
+          <%= f.radio_button :transaction_type, 'sell', class: "btn-check" %>
+          <%= f.label :transaction_type_sell, "Sell", class: 'btn btn-secondary transaction_type_sell_button' %>
         </div>
         <div class="field mb-3">
           <%= f.label :price, class: 'form-label' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,11 @@ Rails.application.routes.draw do
   concern :paginatable do
     get 'page/:page', action: :index, on: :collection, as: ''
   end
+
+  concern :paginatable_transactions do
+    get 'transactions/:page', action: :transactions, on: :collection, as: ''
+  end
   
   resources :stocks, only: [:index], concerns: :paginatable
+  resources :pages, only: [:transactions], concerns: :paginatable_transactions
 end

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.3.0",
     "bootstrap": "5.0.0",
+    "jquery": "^3.6.0",
     "turbolinks": "^5.2.0"
   },
   "version": "0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4028,6 +4028,11 @@ jest-worker@^25.4.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
+jquery@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
+  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
+
 js-base64@^2.1.8:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"


### PR DESCRIPTION
### Story,
As requested during the last checkpoint, instead of having the user select a buy or sell transaction from the dropdown button, separate buttons were introduced for buy and sell. 

Still related to PR #28, the missing plugin has been added and the helper stylesheet_pack_tag is used instead of style_link_tag as the latter only works locally. The former has been tested o production and the bootstrap issue is now fixed.

Some minor changes has also been implemented on the homepage. A header displays the pending status of the user. Also, most active stocks by volume has been added.

### Screenshots

![image](https://user-images.githubusercontent.com/81558435/134672194-305cd221-db5c-4b22-b9a4-ba27379011eb.png)

![image](https://user-images.githubusercontent.com/81558435/134671948-3e6ed124-6cce-40e3-a655-3b0aa4be1f70.png)
